### PR TITLE
Adding support for custom mysql ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ Type: `String`
 
 Description: the hostname for the location in which the database resides.
 
+#### port
+Type: `Number`
+
+Description: the port for which mysql runs on. Leave out for the default `3306`
+
 #### url
 Type: `String`
 

--- a/tasks/lib/util.js
+++ b/tasks/lib/util.js
@@ -141,7 +141,8 @@ exports.init = function (grunt) {
         user: config.user,
         pass: config.pass,
         database: config.database,
-        host: config.host
+        host: config.host,
+        port: config.port || 3306
       }
     });
 
@@ -218,7 +219,7 @@ exports.init = function (grunt) {
 
   var tpls = {
     backup_path: "<%= backups_dir %>/<%= env %>/<%= date %>/<%= time %>",
-    mysqldump: "mysqldump -h <%= host %> -u<%= user %> -p<%= pass %> <%= database %>",
+    mysqldump: "mysqldump -h <%= host %> -u<%= user %> -p<%= pass %> <%= database %> --port <%= port %>",
     mysql: "mysql -h <%= host %> -u <%= user %> -p<%= pass %> <%= database %>",
     rsync_push: "rsync <%= rsync_args %> --delete -e 'ssh <%= ssh_host %>' <%= exclusions %> <%= from %> :<%= to %>",
     rsync_pull: "rsync <%= rsync_args %> -e 'ssh <%= ssh_host %>' <%= exclusions %> :<%= from %> <%= to %>",


### PR DESCRIPTION
Many local LAMP stacks (Like MAMP and MAMP Pro) run on a different port than the default 3306
