### PR TITLE
Escape password to avoid confusing bash

### DIFF
--- a/tasks/lib/util.js
+++ b/tasks/lib/util.js
@@ -138,10 +138,14 @@ exports.init = function (grunt) {
 
   /* Commands generators */
   exports.mysqldump_cmd = function(config) {
+    function escape (str) {
+      return str.replace(/(\(|\))/g, "\\$1");
+    }
+
     var cmd = grunt.template.process(tpls.mysqldump, {
       data: {
         user: config.user,
-        pass: config.pass,
+        pass: escape(config.pass),
         database: config.database,
         host: config.host
       }

--- a/tasks/lib/util.js
+++ b/tasks/lib/util.js
@@ -136,11 +136,12 @@ exports.init = function (grunt) {
     return string.replace(regexp, replace);
   };
 
+  function escape (str) {
+      return str.replace(/(\(|\))/g, "\\$1");
+  }
+
   /* Commands generators */
   exports.mysqldump_cmd = function(config) {
-    function escape (str) {
-      return str.replace(/(\(|\))/g, "\\$1");
-    }
 
     var cmd = grunt.template.process(tpls.mysqldump, {
       data: {
@@ -171,7 +172,7 @@ exports.init = function (grunt) {
       data: {
         host: config.host,
         user: config.user,
-        pass: config.pass,
+        pass: escape(config.pass),
         database: config.database,
         path: src
       }

--- a/tasks/lib/util.js
+++ b/tasks/lib/util.js
@@ -87,6 +87,7 @@ exports.init = function (grunt) {
     var content = grunt.file.read(file);
 
     var output = exports.replace_urls(old_url, new_url, content);
+    output = exports.remove_password_warning(output);
 
     grunt.file.write(file, output);
   };
@@ -134,6 +135,13 @@ exports.init = function (grunt) {
   exports.replace_urls_in_string = function (search, replace, string) {
     var regexp = new RegExp('(?!' + replace + ')(' + search + ')', 'g');
     return string.replace(regexp, replace);
+  };
+
+  exports.remove_password_warning = function (string) {
+    var splitStr = string.split("\n");
+    if (splitStr[0].indexOf("Warning: Using a password on the command line interface can be insecure.") != -1) {
+      return splitStr.slice(1).join("\n");
+    } else {return string};
   };
 
   function escape (str) {

--- a/test/deployments_test.js
+++ b/test/deployments_test.js
@@ -108,18 +108,18 @@ module.exports = {
 
     var config = {
       user: 'john',
-      pass: 'pass',
+      pass: "pas(s))", 
       database: 'test',
       host: 'localhost'
     };
 
     var cmd1 = util.mysqldump_cmd(config);
-    test.equal(cmd1, "mysqldump -h localhost -ujohn -ppass test", 'Local mysqldump command.');
+    test.equal(cmd1, "mysqldump -h localhost -ujohn -ppas\\(s\\)\\) test", 'Local mysqldump command.');
 
     config.ssh_host = '127.0.0.1';
 
     var cmd2 = util.mysqldump_cmd(config);
-    test.equal(cmd2, "ssh 127.0.0.1 'mysqldump -h localhost -ujohn -ppass test'", 'SSH remote mysqldump command.');
+    test.equal(cmd2, "ssh 127.0.0.1 'mysqldump -h localhost -ujohn -ppas\\(s\\)\\) test'", 'SSH remote mysqldump command.');
     test.done();
   },
 

--- a/test/deployments_test.js
+++ b/test/deployments_test.js
@@ -129,19 +129,19 @@ module.exports = {
     var config = {
       host: 'localhost',
       user: 'john',
-      pass: 'pass',
+      pass: 'pas(s))',
       database: 'test',
     };
 
     var src = '/aaa/bbb';
 
     var cmd1 = util.mysql_cmd(config, src);
-    test.equal(cmd1, "mysql -h localhost -u john -ppass test < /aaa/bbb", 'Local Mysql import command.');
+    test.equal(cmd1, "mysql -h localhost -u john -ppas\\(s\\)\\) test < /aaa/bbb", 'Local Mysql import command.');
 
     config.ssh_host = '127.0.0.1';
 
     var cmd2 = util.mysql_cmd(config, src);
-    test.equal(cmd2, "ssh 127.0.0.1 'mysql -h localhost -u john -ppass test' < /aaa/bbb", 'Remote Mysql import command.');
+    test.equal(cmd2, "ssh 127.0.0.1 'mysql -h localhost -u john -ppas\\(s\\)\\) test' < /aaa/bbb", 'Remote Mysql import command.');
     test.done();
   },
 

--- a/test/deployments_test.js
+++ b/test/deployments_test.js
@@ -103,6 +103,17 @@ module.exports = {
     test.done();
   },
 
+  remove_password_warning: function(test) {
+    test.expect(1);
+    var warningStr = "Warning: Using a password on the command line interface can be insecure." + "\n" 
+    + "-- MySQL dump 10.13  Distrib 5.6.17, for Linux (x86_64)" + "\n" 
+    + "yet another test string";
+    test.equal(util.remove_password_warning(warningStr),
+      "-- MySQL dump 10.13  Distrib 5.6.17, for Linux (x86_64)" + "\n" 
+    + "yet another test string");
+    test.done();
+  },
+
   mysqldump_cmd: function(test) {
     test.expect(2);
 


### PR DESCRIPTION
I happened to use a password with paranthesises in it, and it didn't play nice with bash. I first tried using single quotes for hard escaping but I got confused about where in the code I could insert that. 
