### PR TITLE
added dump support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
   "name": "grunt-wordpress-deploy",
   "description": "Deploy Wordpress without pain using Grunt.",
-  "version": "0.0.6",
-  "homepage": "https://github.com/webrain/grunt-wordpress-deploy",
+  "version": "0.0.1",
+  "homepage": "https://github.com/stefnw/grunt-wordpress-deploy",
   "author": {
     "name": "Dario Ghilardi",
-    "email": "darioghilardi@webrain.it",
-    "url": "http://www.webrain.it"
+    "email": "info@snapz.de",
+    "url": "http://www.snapz.de"
   },
   "repository": {
     "type": "git",
     "url": "git@github.com:webrain/grunt-wordpress-deploy.git"
   },
   "bugs": {
-    "url": "https://github.com/webrain/grunt-wordpress-deploy/issues"
+    "url": "https://github.com/stefnw/grunt-wordpress-deploy/issues"
   },
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/webrain/grunt-wordpress-deploy/blob/master/LICENSE-MIT"
+      "url": "https://github.com/stefnw/grunt-wordpress-deploy/blob/master/LICENSE-MIT"
     }
   ],
   "main": "Gruntfile.js",

--- a/tasks/lib/util.js
+++ b/tasks/lib/util.js
@@ -42,6 +42,17 @@ exports.init = function (grunt) {
     grunt.log.oklns("Sync completed successfully.");
   };
 
+    exports.rsync_dump = function (config) {
+        grunt.log.oklns("Dumping data from '" + config.from + "' to '" + config.to + "' with rsync.");
+
+        var cmd = exports.rsync_dump_cmd(config);
+        grunt.log.writeln(cmd);
+
+        shell.exec(cmd);
+
+        grunt.log.oklns("Sync completed successfully.");
+    };
+
   exports.generate_backup_paths = function(target, task_options) {
 
     var backups_dir = task_options['backups_dir'] || "backups";
@@ -218,10 +229,24 @@ exports.init = function (grunt) {
     return cmd;
   };
 
+    exports.rsync_dump_cmd = function (config) {
+        var cmd = grunt.template.process(tpls.rsync_dump, {
+            data: {
+                rsync_args: config.rsync_args,
+                from: config.from,
+                to: config.to,
+                exclusions: config.exclusions
+            }
+        });
+
+        return cmd;
+    };
+
   var tpls = {
     backup_path: "<%= backups_dir %>/<%= env %>/<%= date %>/<%= time %>",
     mysqldump: "mysqldump -h <%= host %> -u<%= user %> -p<%= pass %> <%= database %>",
     mysql: "mysql -h <%= host %> -u <%= user %> -p<%= pass %> <%= database %>",
+    rsync_dump: "rsync <%= rsync_args %> --delete <%= exclusions %> <%= from %> <%= to %>",
     rsync_push: "rsync <%= rsync_args %> --delete -e 'ssh <%= ssh_host %>' <%= exclusions %> <%= from %> :<%= to %>",
     rsync_pull: "rsync <%= rsync_args %> -e 'ssh <%= ssh_host %>' <%= exclusions %> :<%= from %> <%= to %>",
     ssh: "ssh <%= host %>",


### PR DESCRIPTION
Hi,
often you dont have ssh permissions to the live server. if you want to use the grunt-wordpress-deploy functions (especially the url-rewriting) its necessary to build a local instance of your wordpress installation. So i added the functionality to dump the local instance to another local folder with the given url-rewriting function.

Usage:

```
grunt.initConfig({
    pkg: grunt.file.readJSON('package.json'),

    wordpressdeploy: {
        options: {
            backup_dir: "backups/",
            rsync_args: ['--verbose', '--progress', '-rlpt', '--compress', '--omit-dir-times'],
            exclusions: ['Gruntfile.js', '.git/', 'tmp/*']
        },
        local: {
            "title": "local",
            "database": grunt.option('database'),
            "user": grunt.option('user'),
            "pass": grunt.option('pass'),
            "host": grunt.option('host'),
            "url": grunt.option('local_url'),
            "path": grunt.option('local_path')
        },
        dump: {
            "title": "dump",
            "url": grunt.option('livecopy_url'),
            "path": grunt.option('livecopy_path'),
        }
    }
});
```
