### PR TITLE
Adds support for custom DB dump filter functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-wordpress-deploy",
   "description": "Deploy Wordpress without pain using Grunt.",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "homepage": "https://github.com/webrain/grunt-wordpress-deploy",
   "author": {
     "name": "Dario Ghilardi",

--- a/tasks/lib/util.js
+++ b/tasks/lib/util.js
@@ -82,15 +82,20 @@ exports.init = function (grunt) {
     return exclusions;
   };
 
-  exports.db_adapt = function(old_url, new_url, file) {
+  exports.db_adapt = function(old_url, new_url, file, fn_custom_filter) {
 
     var content = grunt.file.read(file);
- 
+
     grunt.log.oklns("Trim warnings from SQL dump.");
-	content = exports.trim_warnings_from_sql_dump(content);
+    content = exports.trim_warnings_from_sql_dump(content);
 
     grunt.log.oklns("Adapt the database: set the correct urls for the destination in the database.");
     var output = exports.replace_urls(old_url, new_url, content);
+
+    if (fn_custom_filter) {
+      grunt.log.oklns("Applying custom filter to database.");
+      output = fn_custom_filter(output);
+    }
 
     grunt.file.write(file, output);
   };

--- a/tasks/lib/util.js
+++ b/tasks/lib/util.js
@@ -83,12 +83,20 @@ exports.init = function (grunt) {
   };
 
   exports.db_adapt = function(old_url, new_url, file) {
-    grunt.log.oklns("Adapt the database: set the correct urls for the destination in the database.");
-    var content = grunt.file.read(file);
 
+    var content = grunt.file.read(file);
+ 
+    grunt.log.oklns("Trim warnings from SQL dump.");
+	content = exports.trim_warnings_from_sql_dump(content);
+
+    grunt.log.oklns("Adapt the database: set the correct urls for the destination in the database.");
     var output = exports.replace_urls(old_url, new_url, content);
 
     grunt.file.write(file, output);
+  };
+
+  exports.trim_warnings_from_sql_dump = function (sql_dump) {
+    return sql_dump.replace(/^Warning.*\n?/gm, '');
   };
 
   exports.replace_urls = function(search, replace, content) {

--- a/tasks/wordpressdeploy.js
+++ b/tasks/wordpressdeploy.js
@@ -1,152 +1,235 @@
-/*
- * grunt-wordpress-deploy
- * https://github.com/webrain/grunt-wordpress-deploy
- *
- * Copyright (c) 2013 Webrain
- * Licensed under the MIT license.
- */
-
 'use strict';
 
-var grunt = require('grunt');
-var util  = require('../tasks/lib/util.js').init(grunt);
+exports.init = function (grunt) {
+  var shell = require('shelljs');
+  var lineReader = require("line-reader");
 
-module.exports = function(grunt) {
+  var exports = {};
 
-  /**
-   * DB PUSH
-   * pushes local database to remote database
-   */
-  grunt.registerTask('push_db', 'Push to Database', function() {
+  exports.db_dump = function(config, output_paths) {
+    grunt.file.mkdir(output_paths.dir);
 
-    var task_options    = grunt.config.get('wordpressdeploy')['options'];
+    var cmd = exports.mysqldump_cmd(config);
 
-    var target = grunt.option('target') || task_options['target'];
+    var output = shell.exec(cmd, {silent: true}).output;
 
-    if ( typeof target === "undefined" || typeof grunt.config.get('wordpressdeploy')[target] === "undefined")  {
-      grunt.fail.warn("Invalid target specified. Did you pass the wrong argument? Please check your task configuration.", 6);
-    }
+    grunt.file.write(output_paths.file, output);
+    grunt.log.oklns("Database DUMP succesfully exported to: " + output_paths.file);
+  };
 
-    // Grab the options
-    var target_options      = grunt.config.get('wordpressdeploy')[target];
-    var local_options       = grunt.config.get('wordpressdeploy').local;
+  exports.db_import = function(config, src) {
+    shell.exec(exports.mysql_cmd(config, src));
+    grunt.log.oklns("Database imported succesfully");
+  };
 
-    // Generate required backup directories and paths
-    var local_backup_paths  = util.generate_backup_paths("local", task_options);
-    var target_backup_paths = util.generate_backup_paths(target, task_options);
+  exports.rsync_push = function(config) {
+    grunt.log.oklns("Syncing data from '" + config.from + "' to '" + config.to + "' with rsync.");
 
-    grunt.log.subhead("Pushing database from 'Local' to '" + target_options.title + "'");
+    var cmd = exports.rsync_push_cmd(config);
+    grunt.log.writeln(cmd);
 
-    // Dump local DB
-    util.db_dump(local_options, local_backup_paths);
+    shell.exec(cmd);
 
-    // Search and Replace database refs
-    util.db_adapt(local_options.url, target_options.url, local_backup_paths.file, target_options.filter);
+    grunt.log.oklns("Sync completed successfully.");
+  };
 
-    // Dump target DB
-    util.db_dump(target_options, target_backup_paths);
+  exports.rsync_pull = function(config) {
+    grunt.log.oklns("Syncing data from '" + config.from + "' to '" + config.to + "' with rsync.");
 
-    // Import dump to target DB
-    util.db_import(target_options, local_backup_paths.file);
+    var cmd = exports.rsync_pull_cmd(config);
+    shell.exec(cmd);
 
-    grunt.log.subhead("Operations completed");
-  });
+    grunt.log.oklns("Sync completed successfully.");
+  };
 
-  /**
-   * DB PULL
-   * pulls remote database into local database
-   */
-  grunt.registerTask('pull_db', 'Pull from Database', function() {
+  exports.generate_backup_paths = function(target, task_options) {
 
-    var task_options = grunt.config.get('wordpressdeploy')['options'];
-    var target       = grunt.option('target') || task_options['target'];
+    var backups_dir = task_options['backups_dir'] || "backups";
 
-    if ( typeof target === "undefined" || typeof grunt.config.get('wordpressdeploy')[target] === "undefined")  {
-      grunt.fail.warn("Invalid target provided. I cannot pull a database from nowhere! Please checked your configuration and provide a valid target.", 6);
-    }
+    var directory = grunt.template.process(tpls.backup_path, {
+      data: {
+        backups_dir: backups_dir,
+        env: target,
+        date: grunt.template.today('yyyymmdd'),
+        time: grunt.template.today('HH-MM-ss'),
+      }
+    });
 
-    // Grab the options
-    var target_options      = grunt.config.get('wordpressdeploy')[target];
-    var local_options       = grunt.config.get('wordpressdeploy').local;
+    var filepath = directory + '/db_backup.sql';
 
-    // Generate required backup directories and paths
-    var local_backup_paths  = util.generate_backup_paths("local", task_options);
-    var target_backup_paths = util.generate_backup_paths(target, task_options);
-
-    // Start execution
-    grunt.log.subhead("Pulling database from '" + target_options.title + "' into Local");
-
-    // Dump Target DB
-    util.db_dump(target_options, target_backup_paths);
-
-    util.db_adapt(target_options.url, local_options.url, target_backup_paths.file, local_options.filter);
-
-    // Backup Local DB
-    util.db_dump(local_options, local_backup_paths);
-
-    // Import dump into Local
-    util.db_import(local_options, target_backup_paths.file);
-
-    grunt.log.subhead("Operations completed");
-  });
-
-  /**
-   * Push files
-   * Sync all local files with the remote location
-   */
-  grunt.registerTask("push_files", "Transfer files to a remote host with rsync.", function () {
-
-    var task_options = grunt.config.get('wordpressdeploy')['options'];
-    var target       = grunt.option('target') || task_options['target'];
-
-    if ( typeof target === "undefined" || typeof grunt.config.get('wordpressdeploy')[target] === "undefined")  {
-      grunt.fail.warn("Invalid target provided. I cannot push files from nowhere! Please checked your configuration and provide a valid target.", 6);
-    }
-
-    // Grab the options
-    var target_options      = grunt.config.get('wordpressdeploy')[target];
-    var local_options       = grunt.config.get('wordpressdeploy').local;
-    var rsync_args = util.compose_rsync_options(task_options.rsync_args);
-    var exclusions = util.compose_rsync_exclusions(task_options.exclusions);
-
-    var config = {
-      rsync_args: task_options.rsync_args.join(' '),
-      ssh_host: target_options.ssh_host,
-      from: local_options.path,
-      to: target_options.path,
-      exclusions: exclusions
+    return {
+      dir: directory,
+      file: filepath
     };
+  };
 
-    util.rsync_push(config);
-  });
+  exports.compose_rsync_options = function(options) {
+    var args = options.join(' ');
 
-  /**
-   * Pull files
-   * Sync all target files with the local location
-   */
-  grunt.registerTask("pull_files", "Transfer files to a remote host with rsync.", function () {
+    return args;
+  };
 
-    var task_options = grunt.config.get('wordpressdeploy')['options'];
-    var target       = grunt.option('target') || task_options['target'];
+  exports.compose_rsync_exclusions = function(options) {
+    var exclusions = '';
+    var i = 0;
 
-    if ( typeof target === "undefined" || typeof grunt.config.get('wordpressdeploy')[target] === "undefined")  {
-      grunt.fail.warn("Invalid target provided. I cannot push files from nowhere! Please checked your configuration and provide a valid target.", 6);
+    for(i = 0;i < options.length; i++) {
+      exclusions += "--exclude '" + options[i] + "' ";
     }
 
-    // Grab the options
-    var target_options      = grunt.config.get('wordpressdeploy')[target];
-    var local_options       = grunt.config.get('wordpressdeploy').local;
-    var rsync_args = util.compose_rsync_options(task_options.rsync_args);
-    var exclusions = util.compose_rsync_exclusions(task_options.exclusions);
+    exclusions = exclusions.trim();
 
-    var config = {
-      rsync_args: rsync_args,
-      ssh_host: target_options.ssh_host,
-      from: target_options.path,
-      to: local_options.path,
-      exclusions: exclusions
-    };
+    return exclusions;
+  };
 
-    util.rsync_pull(config);
-  });
+  exports.db_adapt = function(old_url, new_url, file, fn_custom_filter) {
+
+    var content = grunt.file.read(file);
+
+    grunt.log.oklns("Adapt the database: set the correct urls for the destination in the database.");
+    var output = exports.replace_urls(old_url, new_url, content);
+
+    if (fn_custom_filter) {
+      grunt.log.oklns("Applying custom filter to database.");
+      output = fn_custom_filter(output);
+    }
+
+    grunt.file.write(file, output);
+  };
+
+  exports.replace_urls = function(search, replace, content) {
+    content = exports.replace_urls_in_serialized(search, replace, content);
+    content = exports.replace_urls_in_string(search, replace, content);
+
+    return content;
+  };
+
+  exports.replace_urls_in_serialized = function(search, replace, string) {
+    var length_delta = search.length - replace.length;
+
+    // Replace for serialized data
+    var matches, length, delimiter, old_serialized_data, target_string, new_url;
+    var regexp = /s:(\d+):([\\]*['"])(.*?)\2;/g;
+
+    while (matches = regexp.exec(string)) {
+      old_serialized_data = matches[0];
+      target_string = matches[3];
+
+      // If the string contains the url make the substitution
+      if (target_string.indexOf(search) !== -1) {
+        length = matches[1];
+        delimiter = matches[2];
+
+        // Replace the url
+        new_url = target_string.replace(search, replace);
+        length -= length_delta;
+
+        // Compose the new serialized data
+        var new_serialized_data = 's:' + length + ':' + delimiter + new_url + delimiter + ';';
+
+        // Replace the new serialized data into the dump
+        string = string.replace(old_serialized_data, new_serialized_data);
+      }
+    }
+
+    return string;
+  };
+
+  exports.replace_urls_in_string = function (search, replace, string) {
+    var regexp = new RegExp('(?!' + replace + ')(' + search + ')', 'g');
+    return string.replace(regexp, replace);
+  };
+
+  /* Commands generators */
+  exports.mysqldump_cmd = function(config) {
+    var cmd = grunt.template.process(tpls.mysqldump, {
+      data: {
+        user: config.user,
+        pass: config.pass,
+        database: config.database,
+        host: config.host
+      }
+    });
+
+    if (typeof config.ssh_host === "undefined") {
+      grunt.log.oklns("Creating DUMP of local database");
+    } else {
+      grunt.log.oklns("Creating DUMP of remote database");
+      var tpl_ssh = grunt.template.process(tpls.ssh, {
+        data: {
+          host: config.ssh_host
+        }
+      });
+      cmd = tpl_ssh + " '" + cmd + "'";
+    }
+
+    return cmd;
+  };
+
+  exports.mysql_cmd = function(config, src) {
+    var cmd = grunt.template.process(tpls.mysql, {
+      data: {
+        host: config.host,
+        user: config.user,
+        pass: config.pass,
+        database: config.database,
+        path: src
+      }
+    });
+
+    if (typeof config.ssh_host === "undefined") {
+      grunt.log.oklns("Importing DUMP into local database");
+      cmd = cmd + " < " + src;
+    } else {
+      var tpl_ssh = grunt.template.process(tpls.ssh, {
+        data: {
+          host: config.ssh_host
+        }
+      });
+
+      grunt.log.oklns("Importing DUMP into remote database");
+      cmd = tpl_ssh + " '" + cmd + "' < " + src;
+    }
+
+    return cmd;
+  };
+
+  exports.rsync_push_cmd = function(config) {
+    var cmd = grunt.template.process(tpls.rsync_push, {
+      data: {
+        rsync_args: config.rsync_args,
+        ssh_host: config.ssh_host,
+        from: config.from,
+        to: config.to,
+        exclusions: config.exclusions
+      }
+    });
+
+    return cmd;
+  };
+
+  exports.rsync_pull_cmd = function(config) {
+    var cmd = grunt.template.process(tpls.rsync_pull, {
+      data: {
+        rsync_args: config.rsync_args,
+        ssh_host: config.ssh_host,
+        from: config.from,
+        to: config.to,
+        exclusions: config.exclusions
+      }
+    });
+
+    return cmd;
+  };
+
+  var tpls = {
+    backup_path: "<%= backups_dir %>/<%= env %>/<%= date %>/<%= time %>",
+    mysqldump: "mysqldump -h <%= host %> -u<%= user %> -p<%= pass %> <%= database %>",
+    mysql: "mysql -h <%= host %> -u <%= user %> -p<%= pass %> <%= database %>",
+    rsync_push: "rsync <%= rsync_args %> --delete -e 'ssh <%= ssh_host %>' <%= exclusions %> <%= from %> :<%= to %>",
+    rsync_pull: "rsync <%= rsync_args %> -e 'ssh <%= ssh_host %>' <%= exclusions %> :<%= from %> <%= to %>",
+    ssh: "ssh <%= host %>",
+  };
+
+  return exports;
 };

--- a/tasks/wordpressdeploy.js
+++ b/tasks/wordpressdeploy.js
@@ -77,15 +77,15 @@ module.exports = function(grunt) {
     grunt.log.subhead("Pulling database from '" + target_options.title + "' into Local");
 
     // Dump Target DB
-    util.db_dump(target_options, target_backup_paths );
+    util.db_dump(target_options, target_backup_paths);
 
-    util.db_adapt(target_options.url,local_options.url,target_backup_paths.file);
+    util.db_adapt(target_options.url, local_options.url, target_backup_paths.file, local_options.filter);
 
     // Backup Local DB
     util.db_dump(local_options, local_backup_paths);
 
     // Import dump into Local
-    util.db_import(local_options,target_backup_paths.file);
+    util.db_import(local_options, target_backup_paths.file);
 
     grunt.log.subhead("Operations completed");
   });

--- a/tasks/wordpressdeploy.js
+++ b/tasks/wordpressdeploy.js
@@ -41,7 +41,7 @@ module.exports = function(grunt) {
     util.db_dump(local_options, local_backup_paths);
 
     // Search and Replace database refs
-    util.db_adapt(local_options.url, target_options.url, local_backup_paths.file);
+    util.db_adapt(local_options.url, target_options.url, local_backup_paths.file, target_options.filter);
 
     // Dump target DB
     util.db_dump(target_options, target_backup_paths);


### PR DESCRIPTION
Allows for a custom filter function to run string operations on the DB dump before importing it to each environment.

For example, this allows for custom fixes regarding MySQL warnings as discussed in #6, #37 and #34 by adding the following filter:

``` js
local: {
  'title': 'local',
  //...
  'filter': function(mysql_dump) {
    return mysql_dump.replace(/^Warning.*\n?/gm, ''); // filter MySQL warnings
  }
}
```

I've also used it to switch between wordpress themes when pushing/pulling from/to local:

``` js
local: {
  'title': 'local',
  //...
  'filter': function(mysql_dump) {
    return mysql_dump
      .replace(/^Warning.*\n?/gm, '') // filter MySQL warnings
      .replace(/'(current_theme)','My Production Theme'/g, '\'$1\',\'My Development Theme\'')
      .replace(/'(stylesheet|template)','my-production-theme-folder'/g, '\'$1\',\'my-dev-theme-folder\'');
  }
}
//...
staging: {
  'title': 'staging',
  //...
  'filter': function(mysql_dump) {
    return mysql_dump
      .replace(/^Warning.*\n?/gm, '') // filter MySQL warnings
      .replace(/'(current_theme)','My Development Theme'/g, '\'$1\',\'My Production Theme\'')
      .replace(/'(stylesheet|template)','my-dev-theme-folder'/g, '\'$1\',\'my-production-theme-folder\'');
  }
}
```
